### PR TITLE
Фиксация версии numpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ whitenoise
 django-cors-headers
 sklearn
 scikit-learn==0.23.0
-numpy
+numpy==1.23.5
 gym


### PR DESCRIPTION
Код использует версию numpy, содержащую данные типа, который отсутствует в актуальное версии: https://stackoverflow.com/questions/74844262/how-can-i-solve-error-module-numpy-has-no-attribute-float-in-python

Пример лога запуска без фиксации версии numpy
[numpy_problems.log](https://github.com/ProgMiner/mledu/files/11205576/numpy_problems.log)
